### PR TITLE
URL Update for SSH Using PuTTY-CAC: Section 4

### DIFF
--- a/_piv/engineer/02_ssh.md
+++ b/_piv/engineer/02_ssh.md
@@ -44,7 +44,7 @@ PuTTY-CAC is an open-source SSH client that uses Microsoft's CryptoAPI (CAPI). (
 <br><br>
 [![PuTTY Configuration Window]({{site.baseurl}}/assets/piv/ssh-putty-cac-1.png){:style="float:left"}]({{site.baseurl}}/assets/piv/ssh-putty-cac-1.png){:target="_blank"}{:rel="noopener noreferrer"}
 <br><br>
-4. From the **Windows Security** list, select your PIV/CAC authentication certificate by clicking _OK_. If you don't see your certificate, click _More choices_. (For help with certificates, see [Understanding PIV Certificates](../../piv/details/#understanding-piv-certificates/).
+4. From the **Windows Security** list, select your PIV/CAC authentication certificate by clicking _OK_. If you don't see your certificate, click _More choices_. (For help with certificates, see [Understanding PIV Certificates](../../details/#understand-piv-certificates/).
 <br><br>
 [![Add CAPI Cert - #2]({{site.baseurl}}/assets/piv/winSCP-5.PNG)]({{site.baseurl}}/assets/piv/winSCP-5.PNG){:target="_blank"}{:rel="noopener noreferrer"}
 <br>


### PR DESCRIPTION
Current link(broken): 
(../../piv/details/#understanding-piv-certificates/)

Fixed link:
(../../details/#understand-piv-certificates/)