### PR TITLE
add default path for Ubuntu 20.04 opensc package

### DIFF
--- a/_piv/engineer/01_firefox.md
+++ b/_piv/engineer/01_firefox.md
@@ -55,6 +55,7 @@ Launch **_Firefox_** and load a new _Security Device_ (i.e., the Security Device
 | **Windows** | C:\Windows\System32 | pkcs11.dll | 
 | **macOS**  | /Library/OpenSC/lib/ | pkcs11.so | 
 | **Linux**  | /usr/lib/ | pkcs11.so | 
+| **Ubuntu** | /usr/lib/x86_64-linux-gnu/ | opensc-pkcs11.so |
 
 * Click _Open_ and verify that the module has been loaded. Then, click _OK_ to return to the _Privacy & Security_ options.
 


### PR DESCRIPTION
looks like this update got lost when repo was migrated https://github.com/GSA/piv-guides/pull/276