### PR TITLE
1215 Update OpenSC Wiki Download Link

### DIFF
--- a/_piv/engineer/02_ssh.md
+++ b/_piv/engineer/02_ssh.md
@@ -145,7 +145,7 @@ You can use OpenSC on your macOS computer to authenticate to a remote server wit
 
 {% include alert-warning.html heading = "Use OpenSC Version Greater Than 0.20.0 to avoid Authentication Errors" content="If a version of OpenSC less than 0.20.0 is used, users will encounter errors when performing mTLS with servers that offer TLS 1.3. This can include browser errors like ERR_SSL_CLIENT_AUTH_SIGNATURE_FAILED." %}
 
-1. Install [OpenSC](https://www.github.com/OpenSC/OpenSC/wiki/Download-latest-OpenSC-stable-release){:target="_blank"}{:rel="noopener noreferrer"}. 
+1. Install [OpenSC](https://github.com/OpenSC/OpenSC/wiki#download){:target="_blank"}{:rel="noopener noreferrer"}. 
 2. Insert your PIV/CAC into your card reader.
 3. To view the certificates on your Mac, enter:  
      ```


### PR DESCRIPTION
Version downloads are now on the main OpenSC wiki page and the Download Release page was removed [quite awhile ago](https://github.com/OpenSC/OpenSC/wiki/Home/_compare/ef5ea1f0e0bde6df6b0cdcf2fb890606e42dcfd9...2bc8b9e1400cb1f6647d1257867e83e5ffa64c2a) .

Closes #360 