### PR TITLE
0322 FPKI System Notices

### DIFF
--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -32,7 +32,7 @@
   contact: fpki dash help at gsa dot gov
   ca_certificate_hash: N/A
   ca_certificate_issuer: CN=Federal Common Policy CA G2, OU=FPKI, O=U.S. Government, C=US
-  ca_certificate_subject: CN=US Treasury Root CA, OU=Certification Authorities, OU=Department of the Treasury, O=U.S. Government, C=US
+  ca_certificate_subject: ON=US Treasury Root CA, OU=Certification Authorities, OU=Department of the Treasury, O=U.S. Government, C=US
   cdp_uri: http://repo.fpki.gov/fcpca/fcpcag2.crl
   aia_uri: N/A
   sia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedByfcpcag2.p7c

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -25,6 +25,32 @@
 # sia_uri:
 # ocsp_uri:
 
+- notice_date: March 22, 2022
+  change_type: Intent to Perform CA Certificate Issuance 
+  system: FPKI Trust Infrastructure - Federal Common Policy CA G2 
+  change_description: The Federal Common Policy CA G2 issued a new certificate to the DigiCert Federal SSP Intermediate CA - G6.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: 0dd44fd015c1f76327be46661456ce8f6fb346ec
+  ca_certificate_issuer: CN=Federal Common Policy CA G2, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=DigiCert Federal SSP Intermediate CA - G6, O=DigiCert Inc, C=US
+  cdp_uri: http://repo.fpki.gov/fcpca/fcpcag2.crl
+  aia_uri: N/A
+  sia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedByfcpcag2.p7c
+  ocsp_uri: N/A
+
+- notice_date: March 22, 2022
+  change_type: Intent to Perform CA Certificate Issuance 
+  system: FPKI Trust Infrastructure - Federal Bridge CA G4
+  change_description: The Federal Bridge CA G4 issued a new cross certificate to the DigiCert Federated ID CA - G2.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: a2cadce934df370609b30c42e31c5d2b682ca7b3
+  ca_certificate_issuer: CN=Federal Bridge CA G4, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=DigiCert Federated ID CA - G2, OU=www.digicert.com, O=DigiCert Inc, C=US
+  cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl
+  aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c
+  sia_uri: http://repo.fpki.gov/bridge/caCertsIssuedByfbcag4.p7c
+  ocsp_uri: N/A
+
 - notice_date: February 28, 2022
   change_type: CA Certificate Issuance 
   system: CertiPath Bridge CA 

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -25,8 +25,21 @@
 # sia_uri:
 # ocsp_uri:
 
-- notice_date: March 22, 2022
+- notice_date: March 24, 2022
   change_type: Intent to Perform CA Certificate Issuance 
+  system: FPKI Trust Infrastructure - Federal Common Policy CA G2 
+  change_description: The Federal Common Policy CA G2 intends to issue a new certificate to the US Treasury Root CA between 4/04/2022 and 4/07/2022.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: N/A
+  ca_certificate_issuer: CN=Federal Common Policy CA G2, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=US Treasury Root CA, OU=Certification Authorities, OU=Department of the Treasury, O=U.S. Government, C=US
+  cdp_uri: http://repo.fpki.gov/fcpca/fcpcag2.crl
+  aia_uri: N/A
+  sia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedByfcpcag2.p7c
+  ocsp_uri: N/A
+
+- notice_date: March 22, 2022
+  change_type: CA Certificate Issuance 
   system: FPKI Trust Infrastructure - Federal Common Policy CA G2 
   change_description: The Federal Common Policy CA G2 issued a new certificate to the DigiCert Federal SSP Intermediate CA - G6.
   contact: fpki dash help at gsa dot gov
@@ -39,7 +52,7 @@
   ocsp_uri: N/A
 
 - notice_date: March 22, 2022
-  change_type: Intent to Perform CA Certificate Issuance 
+  change_type: CA Certificate Issuance 
   system: FPKI Trust Infrastructure - Federal Bridge CA G4
   change_description: The Federal Bridge CA G4 issued a new cross certificate to the DigiCert Federated ID CA - G2.
   contact: fpki dash help at gsa dot gov

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -25,7 +25,7 @@
 # sia_uri:
 # ocsp_uri:
 
-- notice_date: March 24, 2022
+- notice_date: March 24, 2022 
   change_type: Intent to Perform CA Certificate Issuance 
   system: FPKI Trust Infrastructure - Federal Common Policy CA G2 
   change_description: The Federal Common Policy CA G2 intends to issue a new certificate to the US Treasury Root CA between 4/04/2022 and 4/07/2022.

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -32,7 +32,7 @@
   contact: fpki dash help at gsa dot gov
   ca_certificate_hash: N/A
   ca_certificate_issuer: CN=Federal Common Policy CA G2, OU=FPKI, O=U.S. Government, C=US
-  ca_certificate_subject: ON=US Treasury Root CA, OU=Certification Authorities, OU=Department of the Treasury, O=U.S. Government, C=US
+  ca_certificate_subject: OU=US Treasury Root CA, OU=Certification Authorities, OU=Department of the Treasury, O=U.S. Government, C=US
   cdp_uri: http://repo.fpki.gov/fcpca/fcpcag2.crl
   aia_uri: N/A
   sia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedByfcpcag2.p7c

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -34,8 +34,8 @@
   ca_certificate_issuer: CN=Federal Common Policy CA G2, OU=FPKI, O=U.S. Government, C=US
   ca_certificate_subject: OU=US Treasury Root CA, OU=Certification Authorities, OU=Department of the Treasury, O=U.S. Government, C=US
   cdp_uri: http://repo.fpki.gov/fcpca/fcpcag2.crl
-  aia_uri: N/A
-  sia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedByfcpcag2.p7c
+  aia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedTofcpcag2.p7c
+  sia_uri: http://pki.treasury.gov/root_sia.p7c
   ocsp_uri: N/A
 
 - notice_date: March 22, 2022
@@ -47,8 +47,8 @@
   ca_certificate_issuer: CN=Federal Common Policy CA G2, OU=FPKI, O=U.S. Government, C=US
   ca_certificate_subject: CN=DigiCert Federal SSP Intermediate CA - G6, O=DigiCert Inc, C=US
   cdp_uri: http://repo.fpki.gov/fcpca/fcpcag2.crl
-  aia_uri: N/A
-  sia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedByfcpcag2.p7c
+  aia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedTofcpcag2.p7c
+  sia_uri: http://ssp-sia.digicert.com/SSP/Certs_issued_by_SSPCAG6.p7c
   ocsp_uri: N/A
 
 - notice_date: March 22, 2022
@@ -61,7 +61,7 @@
   ca_certificate_subject: CN=DigiCert Federated ID CA - G2, OU=www.digicert.com, O=DigiCert Inc, C=US
   cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl
   aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c
-  sia_uri: http://repo.fpki.gov/bridge/caCertsIssuedByfbcag4.p7c
+  sia_uri: N/A
   ocsp_uri: N/A
 
 - notice_date: February 28, 2022


### PR DESCRIPTION
Updates to FPKI system notifications includes:

Issuance of 2 Digicert CAs (one Common and one Bridge) and
Intent to issue a new Treasury Root CA from the FCPCAG2 to include the common PIV-I OIDs

Closes #460 
Closes #462 