### PR TITLE
Update Navigation and Heading

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # Be sure to edit the values below
 ##########################################################################################
 
-title: FICAM Playbooks
+title: FICAM Architecture
 email: icam@gsa.gov
 description: Helping the U.S. Federal Government Enterprise design, procure, integrate, and operate Federal Enterprise Identity, Credential, and Access Management services.
 baseurl: ""
@@ -39,9 +39,9 @@ ga:
 
 # Site Navigation
 primary_navigation:
-  - name: Playbooks Home
+  - name: Home
     url: /
-  - name: FICAM Architecture
+  - name: Architecture
     children:
       - name: Introduction
         url: /arch/

--- a/_config.yml
+++ b/_config.yml
@@ -101,7 +101,7 @@ primary_navigation:
         url: /piv/user-guide/outlook/
       - name: Digitally Sign Federal Register Document
         url: /playbooks/signfedregister/
-  - name: User Guides
+  - name: Engineer Guides
     children:
       - name: PIV-Enable Windows Domain
         url: /piv/network/

--- a/_config.yml
+++ b/_config.yml
@@ -39,12 +39,20 @@ ga:
 
 # Site Navigation
 primary_navigation:
-  - name: Playbooks Home
-    description: FICAM Playbooks Home Page
-    url: /
   - name: FICAM Architecture
-    description: FICAM Architecture
-    url: /arch/
+    children:
+      - name: Introduction
+        url: /arch/
+      - name: Goals and Objectives
+        url: /arch/goals/
+      - name: Services Framework
+        url: /arch/services/
+      - name: Use Case
+        url: /arch/usecases/
+      - name: System Components
+        url: /arch/components/
+      - name: Standards and Policies
+        url: /arch/standards/
   - name: Identity
     children:
       - name: Identity Management Overview

--- a/_config.yml
+++ b/_config.yml
@@ -121,6 +121,8 @@ primary_navigation:
         url: /piv/engineer/firefox/
       - name: PIV-Enable SSH
         url: /piv/engineer/ssh/
+  - name: Tools
+    children: 
       - name: FPKI System Change Notifications
         url: /fpki/notifications/
       - name: FPKI Useful Tools

--- a/_config.yml
+++ b/_config.yml
@@ -93,7 +93,7 @@ primary_navigation:
         url: /playbooks/dira/
       - name: ICAM Governance Framework
         url: /docs/playbook-identity-governance-framework.pdf
-  - name: Guides
+  - name: User Guides
     children:
       - name: Digitally Sign Word Document
         url: /playbooks/signword/
@@ -101,6 +101,8 @@ primary_navigation:
         url: /piv/user-guide/outlook/
       - name: Digitally Sign Federal Register Document
         url: /playbooks/signfedregister/
+  - name: User Guides
+    children:
       - name: PIV-Enable Windows Domain
         url: /piv/network/
       - name: PIV-Enable macOS

--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,8 @@ ga:
 
 # Site Navigation
 primary_navigation:
+  - name: Playbooks Home
+    url: /
   - name: FICAM Architecture
     children:
       - name: Introduction
@@ -101,7 +103,7 @@ primary_navigation:
         url: /playbooks/dira/
       - name: ICAM Governance Framework
         url: /docs/playbook-identity-governance-framework.pdf
-  - name: User Guides
+  - name: Playbooks
     children:
       - name: Digitally Sign Word Document
         url: /playbooks/signword/
@@ -109,8 +111,6 @@ primary_navigation:
         url: /piv/user-guide/outlook/
       - name: Digitally Sign Federal Register Document
         url: /playbooks/signfedregister/
-  - name: Engineer Guides
-    children:
       - name: PIV-Enable Windows Domain
         url: /piv/network/
       - name: PIV-Enable macOS


### PR DESCRIPTION
Update the top-level navigation to include architecture sections and rename the site to FICAM architecture.