### PR TITLE
Update fpki-system-notification.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/fpki-system-notification.md
+++ b/.github/ISSUE_TEMPLATE/fpki-system-notification.md
@@ -17,7 +17,9 @@ contact:
 ca_certificate_hash: 
 ca_certificate_issuer: 
 ca_certificate_subject: 
-cdp_uri: 
-aia_uri: 
-sia_uri: 
-ocsp_uri:
+ca_cdp_uri: 
+ca_aia_uri: 
+ca_sia_uri: 
+ca_ocsp_uri:
+ee_cdp_uri:
+ee_ocsp_uri:  


### PR DESCRIPTION
Added end entity (ee) CRL DP and OCSP categories to the FPKI system notification template in the event we can collect that information from the issuers.  The purpose will be to assist OCSP/SCVP implementers to accept certificates off of new CAs more efficiently.

This template change also helps to differentiate the CA certificate information (CDP, OCSP, AIA) from that of the end entities it issues.