### PR TITLE
0725 FPKI Notifications

### DIFF
--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -26,6 +26,22 @@
 # ee_cdp_uri:
 # ee_ocsp_uri:
 
+- notice_date: July 21, 2023
+  change_type: Intent to Issue a CA Certificate
+  system: CertiPath Bridge CA
+  change_description: The CertiPath Bridge CA-G3 plans to issue a renewed cross certificate to the Raytheon Technologies Medium Assurance CA.
+  contact: support at certipath dot com
+### The following are all optional fields based on the change type
+  ca_certificate_hash: TBD
+  ca_certificate_issuer: OCN=CertiPath Bridge CA - G3, OU=Certification Authorities, O=CertiPath, C=US
+  ca_certificate_subject: CN=Raytheon Technologies Medium Assurance CA, OU=Class3-G3, O=cas, DC=rtx, DC=com
+  cdp_uri: http://crl.certipath.com/CertiPathBridgeCA-G3.crl
+  aia_uri: http://aia.certipath.com/CertiPathBridgeCA-G3.p7c
+  sia_uri: http://pki.treasury.gov/vaca_sia.p7c
+  ocsp_uri: N/A
+  ee_cdp_uri: http://pki.rtx.com/G3/CRLs/Class3-G3_Full.crl
+  ee_ocsp_uri: N/A
+
 - notice_date: June 28, 2023
   change_type: CA Certificate Issuance
   system: US Treasury Root CA


### PR DESCRIPTION
Add a notification on CertiPath's intent to issue a new CA certificate to Raytheon. 

This May not be pulled into production in time for the migration, but all of the same information is also in the idm.gov notifications yml.

Closes #964 